### PR TITLE
Adds the binding of the autofocus attribute

### DIFF
--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -4,7 +4,8 @@ const {
   Component,
   computed,
   get,
-  set
+  set,
+  run
 } = Ember;
 
 const OneWayInputComponent = Component.extend({
@@ -13,6 +14,7 @@ const OneWayInputComponent = Component.extend({
   attributeBindings: [
     'accept',
     'autocomplete',
+    'autofocus',
     'autosave',
     'checked',
     'dir',
@@ -93,6 +95,13 @@ const OneWayInputComponent = Component.extend({
     set(this, 'value', value);
     this._sanitizedValue = get(this, get(this, 'appropriateAttr'));
     this._processNewValue('update', get(this, get(this, 'appropriateAttr')));
+  },
+
+  didInsertElement() {
+    this._super(...arguments);
+    if (get(this, 'autofocus')) {
+      run.scheduleOnce('afterRender', this, () => this.$().focus());
+    }
   }
 });
 

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -2,6 +2,8 @@ import { skip, test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 const TEXT = '#one-way-text';
+const TEXT_AUTOFOCUS = '#one-way-text-autofocus';
+const BUTTON_AUTOFOCUS = '#show-text-autofocus';
 const TEXT_KEYEVENTS = '#one-way-text-keyevents';
 const CHECKBOX = '#one-way-checkbox';
 const NUMBER_INPUT = '#one-way-number';
@@ -35,6 +37,15 @@ test('it responds to key events', function(assert) {
     keyEvent(TEXT_KEYEVENTS, 'keyup', 27).then(() => {
       assert.equal(findWithAssert('#committed').text().trim(), 'hit escape', 'should update `committed` onescape');
     });
+  });
+});
+
+test('it handles autofocus', function (assert) {
+  visit('/');
+
+  andThen(() => click(BUTTON_AUTOFOCUS));
+  andThen(() => {
+    assert.equal(findWithAssert(TEXT_AUTOFOCUS)[0], document.activeElement, 'input should be focused');
   });
 });
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,10 +7,15 @@ export default Controller.extend({
   textCurrentValue: 'foo',
   numberCurrentValue: 0,
 
+  autoFocusShown: false,
+
   actions: {
     noop: K,
     commit(value) {
       set(this, 'committed', value);
+    },
+    showAutoFocusInput() {
+      set(this, 'autoFocusShown', true);
     }
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -26,6 +26,16 @@
   onescape=(action "commit")
 }}
 
+<div>
+<button id="show-text-autofocus" {{action 'showAutoFocusInput'}} />
+{{#if autoFocusShown}}
+  {{one-way-input
+    id="one-way-text-autofocus"
+    autofocus='autofocus'
+  }}
+{{/if}}
+</div>
+
 <div id="checkbox-current-value">
   {{checkboxCurrentValue}}
 </div>


### PR DESCRIPTION
This PR adds the autofocus option to the input, few comments on this commit:

- I do not simply binds the html5 autofocus attribute because ember's input may be inserted after the onload event of document.

- I have to schedule the focus after the render to be sure the DOM element is ready (had cases, using input in modals for exemple, where it would not work otherwise)

- cannot use `.is(':focus')`in test due to a PhantomJS bug ( ariya/phantomjs#10427 )