### PR TITLE
Rename addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ember-one-way-input [![Build Status](https://travis-ci.org/dockyard/ember-one-way-input.svg?branch=master)](https://travis-ci.org/dockyard/ember-one-way-input) [![npm version](https://badge.fury.io/js/ember-one-way-input.svg)](https://badge.fury.io/js/ember-one-way-input)
+# ember-one-way-controls [![Build Status](https://travis-ci.org/dockyard/ember-one-way-controls.svg?branch=master)](https://travis-ci.org/dockyard/ember-one-way-controls) [![npm version](https://badge.fury.io/js/ember-one-way-controls.svg)](https://badge.fury.io/js/ember-one-way-controls)
 *Credit: @rwjblue's [twiddle](https://gist.github.com/rwjblue/2d7246875098d0dbb4a4)*
 
 Demo: http://ember-twiddle.com/2d7246875098d0dbb4a4

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,1 @@
+export { default as OneWayInput } from 'ember-one-way-controls/components/one-way-input';

--- a/app/components/one-way-input.js
+++ b/app/components/one-way-input.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-one-way-input/components/one-way-input';
+export { default } from 'ember-one-way-controls/components/one-way-input';

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-one-way-input",
+  "name": "ember-one-way-controls",
   "dependencies": {
     "ember": "2.1.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-one-way-input'
+  name: 'ember-one-way-controls'
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ember-one-way-input",
+  "name": "ember-one-way-controls",
   "version": "0.4.0",
-  "description": "Native one way input",
+  "description": "Native one way controls",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/dockyard/ember-one-way-input",
+  "repository": "https://github.com/dockyard/ember-one-way-controls",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
- [ ] Deprecate old package on npm
- [ ] Republish as `ember-one-way-controls`