### PR TITLE
Make select prompt disabled by default

### DIFF
--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -6,8 +6,9 @@ import { invokeAction } from 'ember-invoke-action';
 const {
   Component,
   computed,
-  computed: { alias },
+  computed: { alias, not },
   get,
+  isBlank,
   set,
   String: { w }
 } = Ember;
@@ -34,8 +35,14 @@ export default Component.extend({
       options = w(options);
     }
 
+    if (isBlank(get(this, 'promptIsSelectable'))) {
+      set(this, 'promptIsSelectable', false);
+    }
+
     set(this, 'options', Ember.A(options));
   },
+
+  promptIsDisabled: not('promptIsSelectable'),
 
   optionGroups: computed('options.[]', function() {
     const groupLabelPath = get(this, 'groupLabelPath');

--- a/addon/templates/components/one-way-select.hbs
+++ b/addon/templates/components/one-way-select.hbs
@@ -1,5 +1,5 @@
 {{#if includeBlank}}
-  <option value="">{{promptText}}</option>
+  <option value="" disabled={{promptIsDisabled}}>{{promptText}}</option>
 {{/if}}
 {{#if groupLabelPath}}
   {{#each optionGroups as |optionGroup|}}

--- a/tests/integration/components/one-way-select-test.js
+++ b/tests/integration/components/one-way-select-test.js
@@ -44,6 +44,7 @@ test('Can include a blank value', function(assert) {
 test('Blank value can be given a text', function(assert) {
   this.render(hbs`{{one-way-select value=value options=options includeBlank="Select one"}}`);
   assert.equal(this.$('option:eq(0)').text().trim(), 'Select one', 'The blank option has "Select one" as label');
+  assert.equal(this.$('option:eq(0):disabled').length, 1, 'The blank option is disabled by default');
 });
 
 test('Prompt is an alias for includeBlank', function(assert) {
@@ -63,6 +64,11 @@ test('With prompt selection still works properly', function(assert) {
   this.$('select').trigger('change');
   assert.equal(this.$('option:selected').val(), 'male', 'Select options is male');
   assert.equal(this.get('value'), 'male', 'Value us \'male\'');
+});
+
+test('Prompt can be selectable', function(assert) {
+  this.render(hbs`{{one-way-select value=value options=options prompt="Select one" promptIsSelectable=true}}`);
+  assert.equal(this.$('option:eq(0):disabled').length, 0, 'The blank option is enabled');
 });
 
 test('optionLabelPath', function(assert) {


### PR DESCRIPTION
Or should it be enabled by default, and optionally disabled?