### PR TITLE
Only use the ember-get-helper on 1.13.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,25 +60,16 @@ This addon will work on Ember versions `1.13.x` and up.
 
 ## Installation
 
-* `git clone` this repository
-* `npm install`
-* `bower install`
+```shell
+ember install ember-one-way-controls
+```
 
-## Running
+If the app uses Ember 1.13, then you will need to install the `ember-get-helper`
+addon:
 
-* `ember server`
-* Visit your app at http://localhost:4200.
-
-## Running Tests
-
-* `ember test`
-* `ember test --server`
-
-## Building
-
-* `ember build`
-
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
+```shell
+ember install ember-get-helper
+```
 
 ## Legal
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,78 +3,101 @@ module.exports = {
   scenarios: [
     {
       name: 'default',
-      dependencies: { }
+      bower: {
+        dependencies: { }
+      }
     },
     {
       name: 'ember-1.13',
-      dependencies: {
-        'ember': '~1.13.0'
+      bower: {
+        dependencies: {
+          'ember': '~1.13.0'
+        },
+        resolutions: {
+          'ember': '~1.13.0'
+        }
       },
-      resolutions: {
-        'ember': '~1.13.0'
+      npm: {
+        dependencies: {
+          'ember-get-helper': '~1.0.4',
+        }
       }
     },
     {
       name: 'ember-2.0',
-      dependencies: {
-        'ember': '~2.0.0'
-      },
-      resolutions: {
-        'ember': '~2.0.0'
+      bower: {
+        dependencies: {
+          'ember': '~2.0.0'
+        },
+        resolutions: {
+          'ember': '~2.0.0'
+        }
       }
     },
     {
       name: 'ember-2.1',
-      dependencies: {
-        'ember': '~2.1.0'
-      },
-      resolutions: {
-        'ember': '~2.1.0'
+      bower: {
+        dependencies: {
+          'ember': '~2.1.0'
+        },
+        resolutions: {
+          'ember': '~2.1.0'
+        }
       }
     },
     {
       name: 'ember-2.2',
-      dependencies: {
-        'ember': '~2.2.0'
-      },
-      resolutions: {
-        'ember': '~2.2.0'
+      bower: {
+        dependencies: {
+          'ember': '~2.2.0'
+        },
+        resolutions: {
+          'ember': '~2.2.0'
+        }
       }
     },
     {
       name: 'ember-2.3',
-      dependencies: {
-        'ember': '~2.3.0'
-      },
-      resolutions: {
-        'ember': '~2.3.0'
+      bower: {
+        dependencies: {
+          'ember': '~2.3.0'
+        },
+        resolutions: {
+          'ember': '~2.3.0'
+        }
       }
     },
     {
       name: 'ember-release',
-      dependencies: {
-        'ember': 'components/ember#release'
-      },
-      resolutions: {
-        'ember': 'release'
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
       }
     },
     {
       name: 'ember-beta',
-      dependencies: {
-        'ember': 'components/ember#beta'
-      },
-      resolutions: {
-        'ember': 'beta'
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#beta'
+        },
+        resolutions: {
+          'ember': 'beta'
+        }
       }
     },
     {
       name: 'ember-canary',
-      dependencies: {
-        'ember': 'components/ember#canary'
-      },
-      resolutions: {
-        'ember': 'canary'
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#canary'
+        },
+        resolutions: {
+          'ember': 'canary'
+        }
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-try": "~0.0.8"
+    "ember-try": "0.1.2"
   },
   "keywords": [
     "ember-addon"
@@ -44,7 +44,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-get-helper": "1.0.4",
     "ember-invoke-action": "1.2.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Better to use the baked in get helper over a unsupported one, when we can.