### PR TITLE
Add required attribute

### DIFF
--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -33,6 +33,7 @@ const OneWayInputComponent = Component.extend({
     'name',
     'pattern',
     'placeholder',
+    'required',
     'size',
     'step',
     'type',


### PR DESCRIPTION
It would be nice to add the `required` attribute on inputs. I use these in a few places (Mostly for styling hacks), but the documentation can be found [here](http://www.w3schools.com/tags/att_input_required.asp). Not sure if you can think of a reason not to.