### PR TITLE
Fix the update callback for select with pre-grouped options

### DIFF
--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -136,14 +136,23 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
   _findOption(value) {
     let options = get(this, 'options');
     let optionValuePath = get(this, 'optionValuePath');
+    let optionsArePreGrouped = get(this, 'optionsArePreGrouped');
 
-    return options.find((item) => {
+    let findOption = (item) => {
       if (optionValuePath) {
         return `${get(item, optionValuePath)}` === value;
       } else {
         return `${item}` === value;
       }
-    });
+    };
+
+    if (optionsArePreGrouped) {
+      return options.reduce((found, group) => {
+        return found || get(group, 'options').find(findOption);
+      }, undefined);
+    } else {
+      return options.find(findOption);
+    }
   },
 });
 

--- a/tests/integration/components/one-way-select-test.js
+++ b/tests/integration/components/one-way-select-test.js
@@ -36,6 +36,29 @@ test('Selecting a value updates the selected value', function(assert) {
   assert.equal(this.get('value'), 'male', 'Value is \'male\'');
 });
 
+test('Selecting a value updates the selected value for pre-grouped options', function(assert) {
+  const groups = [
+    {
+      groupName: 'group1',
+      options: [ 'value1' ]
+    }, {
+      groupName: 'group2',
+      options: [ 'value2' ]
+    }
+  ];
+
+  this.set('options', groups);
+  this.on('update', (value) => this.set('value', value));
+
+  this.render(hbs`{{one-way-select value=value options=options update=(action 'update')}}`);
+
+  this.$('select').val('value2');
+  this.$('select').trigger('change');
+
+  assert.equal(this.$('option:selected').val(), 'value2', 'value2 is selected');
+  assert.equal(this.get('value'), 'value2', 'Value is \'value2\'');
+});
+
 test('Accepts a space seperated string for options', function(assert) {
   this.render(hbs`{{one-way-select value=value options="male female"}}`);
   assert.equal(this.$('option').length, 2, 'There are two options: male, female');


### PR DESCRIPTION
In case of pre-grouped options, the update callback returns `undefined` as value instead of the selected item.

This PR should fix this.