### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: node_js
 node_js:
   - "stable"
 
-sudo: false
+sudo: required
+dist: trusty
 
 addons:
   apt:


### PR DESCRIPTION
Installing Google Chrome on Travis's Docker builds is failing, trying a GCE build instead.
Also looks like the GCE builds have more capacity now.