### PR TITLE
Split implementation of checkbox and input

### DIFF
--- a/addon/-private/dynamic-attribute-bindings.js
+++ b/addon/-private/dynamic-attribute-bindings.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+const { Mixin, set } = Ember;
+
+export default Mixin.create({
+  init() {
+    this._super(...arguments);
+
+    let newAttributeBindings = [];
+    for (let key in this.attrs) {
+      if (this.NON_ATTRIBUTE_BOUND_PROPS.indexOf(key) === -1 && this.attributeBindings.indexOf(key) === -1) {
+        newAttributeBindings.push(key);
+      }
+    }
+
+    set(this, 'attributeBindings', this.attributeBindings.concat(newAttributeBindings));
+  }
+});

--- a/addon/components/one-way-checkbox.js
+++ b/addon/components/one-way-checkbox.js
@@ -1,15 +1,31 @@
 import Ember from 'ember';
-import OneWayInputComponent from './one-way-input';
+import { invokeAction } from 'ember-invoke-action';
+import DynamicAttributeBindings from '../-private/dynamic-attribute-bindings';
 
 const {
+  Component,
   get,
   set
 } = Ember;
 
-const OneWayCheckboxComponent = OneWayInputComponent.extend({
+const OneWayCheckboxComponent = Component.extend(DynamicAttributeBindings, {
+  tagName: 'input',
   type: 'checkbox',
 
+  NON_ATTRIBUTE_BOUND_PROPS: ['update'],
+
+  attributeBindings: [
+    'checked',
+    'type',
+    'value'
+  ],
+
+  click() {
+    invokeAction(this, 'update', this.readDOMAttr('checked'));
+  },
+
   didReceiveAttrs() {
+    this._super(...arguments);
     let value = get(this, 'paramChecked') || get(this, 'checked');
     set(this, 'checked', value);
   }

--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -1,25 +1,25 @@
 import Ember from 'ember';
 import { invokeAction } from 'ember-invoke-action';
+import DynamicAttributeBindings from '../-private/dynamic-attribute-bindings';
 
 const {
   Component,
-  computed,
   get,
   set
 } = Ember;
 
-const NON_ATTRIBUTE_BOUND_PROPS = [
-  'keyEvents',
-  'update',
-  'sanitizeInput'
-];
 
-const OneWayInputComponent = Component.extend({
+const OneWayInputComponent = Component.extend(DynamicAttributeBindings, {
   tagName: 'input',
   type: 'text',
 
+  NON_ATTRIBUTE_BOUND_PROPS: [
+    'keyEvents',
+    'update',
+    'sanitizeInput'
+  ],
+
   attributeBindings: [
-    'checked',
     'type',
     'value'
   ],
@@ -29,72 +29,52 @@ const OneWayInputComponent = Component.extend({
     '27': 'onescape'
   },
 
-  _sanitizedValue: undefined,
-
   input() { this._handleChangeEvent(); },
   change() { this._handleChangeEvent(); },
   keyUp(event) { this._interpretKeyEvents(event); },
 
-  appropriateAttr: computed('type', function() {
-    let type = get(this, 'type');
-
-    return type === 'checkbox' ? 'checked' : 'value';
-  }),
-
   _interpretKeyEvents(event) {
-    let methodName = this.keyEvents[event.keyCode];
+    let method = get(this, `keyEvents.${event.keyCode}`);
 
-    if (methodName) {
+    if (method) {
       this._sanitizedValue = null;
-      this._processNewValue(methodName, this.readDOMAttr(get(this, 'appropriateAttr')));
+      this._handleChangeEvent(method);
     }
   },
 
-  _handleChangeEvent() {
-    this._processNewValue('update', this.readDOMAttr(get(this, 'appropriateAttr')));
+  _handleChangeEvent(method = 'update') {
+    let value = this.readDOMAttr('value');
+    this._processNewValue(method, value);
   },
 
-  _processNewValue(methodName, rawValue) {
+  _processNewValue(method, rawValue) {
     let value = this.sanitizeInput(rawValue);
 
     if (this._sanitizedValue !== value) {
       this._sanitizedValue = value;
 
-      if (typeof methodName === 'function') {
-        methodName(value);
+      if (typeof method === 'function') {
+        method(value);
       } else {
-        invokeAction(this, methodName, value);
+        invokeAction(this, method, value);
       }
     }
-  },
-
-  _bindDynamicAttributes() {
-    let newAttributeBindings = [];
-    for (let key in this.attrs) {
-      if (!NON_ATTRIBUTE_BOUND_PROPS[key] && this.attributeBindings.indexOf(key) === -1) {
-        newAttributeBindings.push(key);
-      }
-    }
-
-    set(this, 'attributeBindings', this.attributeBindings.concat(newAttributeBindings));
   },
 
   sanitizeInput(input) {
     return input;
   },
 
-  init() {
-    this._super(...arguments);
-    this._bindDynamicAttributes();
-  },
 
   didReceiveAttrs() {
     this._super(...arguments);
 
     let value = get(this, 'paramValue') || get(this, 'value');
+
     set(this, 'value', value);
-    this._sanitizedValue = get(this, get(this, 'appropriateAttr'));
-    this._processNewValue('update', get(this, get(this, 'appropriateAttr')));
+
+    this._sanitizedValue = value;
+    this._processNewValue('update', value);
   }
 });
 

--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/one-way-select';
+import DynamicAttributeBindings from '../-private/dynamic-attribute-bindings';
 
 import { invokeAction } from 'ember-invoke-action';
 
@@ -16,18 +17,24 @@ const {
   String: { w }
 } = Ember;
 
-const OneWaySelectComponent = Component.extend({
+const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
   layout,
   tagName: 'select',
 
+  NON_ATTRIBUTE_BOUND_PROPS: [
+    'value',
+    'update',
+    'options',
+    'prompt',
+    'promptText',
+    'includeBlank',
+    'optionValuePath',
+    'optionLabelPath',
+    'groupLabelPath'
+  ],
+
   attributeBindings: [
-    'autofocus',
-    'disabled',
-    'form',
     'multiple',
-    'name',
-    'required',
-    'size'
   ],
 
   didReceiveAttrs() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -30,9 +30,8 @@
   {{checkboxCurrentValue}}
 </div>
 
-{{one-way-input
+{{one-way-checkbox
   id="one-way-checkbox"
-  type="checkbox"
   checked=checkboxCurrentValue
   update=(action (mut checkboxCurrentValue))
 }}


### PR DESCRIPTION
Having the checkbox extend from the input felt like being the
wrong abstraction. It also made the implementation of input a
bit more difficult to grasp what's going on.