### PR TITLE
Ignore class attribute when dynamically binding attributes

### DIFF
--- a/addon/-private/dynamic-attribute-bindings.js
+++ b/addon/-private/dynamic-attribute-bindings.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 const { Mixin, set } = Ember;
 
 export default Mixin.create({
+  NON_ATTRIBUTE_BOUND_PROPS: ['class'],
+  concatenatedProperties: ['NON_ATTRIBUTE_BOUND_PROPS'],
   init() {
     this._super(...arguments);
 

--- a/tests/integration/components/one-way-checkbox-test.js
+++ b/tests/integration/components/one-way-checkbox-test.js
@@ -49,3 +49,8 @@ test('It can accept an outside toggle of checked', function(assert) {
 
   assert.strictEqual(this.get('checked'), true);
 });
+
+test('I can add a class attribute', function(assert) {
+  this.render(hbs`{{one-way-checkbox class="testing"}}`);
+  assert.equal(true, this.$('input').hasClass('testing'));
+});

--- a/tests/integration/components/one-way-input-test.js
+++ b/tests/integration/components/one-way-input-test.js
@@ -127,3 +127,8 @@ test('Raises AssertionError when type is "radio"', function(assert) {
     this.render(hbs`{{one-way-input type="radio"}}`);
   }, 'The {{one-way-input}} component does not support type="radio", use {{one-way-radio}} instead.');
 });
+
+test('I can add a class attribute', function(assert) {
+  this.render(hbs`{{one-way-input class="testing"}}`);
+  assert.equal(true, this.$('input').hasClass('testing'));
+});

--- a/tests/integration/components/one-way-radio-test.js
+++ b/tests/integration/components/one-way-radio-test.js
@@ -56,3 +56,8 @@ test('Triggers update action when clicked in a radio button group', function(ass
 
   this.$('input[value="yes"]').click();
 });
+
+test('I can add a class attribute', function(assert) {
+  this.render(hbs`{{one-way-radio class="testing"}}`);
+  assert.equal(true, this.$('input').hasClass('testing'));
+});

--- a/tests/integration/components/one-way-select-test.js
+++ b/tests/integration/components/one-way-select-test.js
@@ -229,3 +229,8 @@ test('It handles the old style of actions', function(assert) {
   this.$('select').trigger('change');
   assert.equal(fired, true, 'The update action should have fired');
 });
+
+test('I can add a class attribute', function(assert) {
+  this.render(hbs`{{one-way-select class="testing"}}`);
+  assert.equal(true, this.$('select').hasClass('testing'));
+});

--- a/tests/integration/components/one-way-textarea-test.js
+++ b/tests/integration/components/one-way-textarea-test.js
@@ -9,3 +9,8 @@ test('It renders a textarea', function(assert) {
   this.render(hbs`{{one-way-textarea}}`);
   assert.equal(this.$('textarea').length, 1, 'a textarea was rendered');
 });
+
+test('I can add a class attribute', function(assert) {
+  this.render(hbs`{{one-way-textarea class="testing"}}`);
+  assert.equal(true, this.$('textarea').hasClass('testing'));
+});


### PR DESCRIPTION
Simple fix for https://github.com/DockYard/ember-one-way-controls/issues/80