### PR TITLE
update ember-hash-helper-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-hash-helper-polyfill": "0.1.0",
+    "ember-hash-helper-polyfill": "^0.1.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-suave": "2.0.1",


### PR DESCRIPTION
gets rid of the deprecation warning in ember-cli