### PR TITLE
update ember-get-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-get-helper": "1.0.4",
+    "ember-get-helper": "~1.1.0",
     "ember-invoke-action": "1.3.0"
   },
   "ember-addon": {


### PR DESCRIPTION
gets rid of the deprecation warning in ember-cli