### PR TITLE
Start testing against alpha (allowed to fail).

### DIFF
--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -6,7 +6,8 @@ const {
   Component,
   assert,
   get,
-  set
+  set,
+  run
 } = Ember;
 
 const OneWayInputComponent = Component.extend(DynamicAttributeBindings, {
@@ -62,11 +63,17 @@ const OneWayInputComponent = Component.extend(DynamicAttributeBindings, {
     if (this._sanitizedValue !== value) {
       this._sanitizedValue = value;
 
-      if (typeof method === 'function') {
-        method(value);
-      } else {
-        invokeAction(this, method, value);
-      }
+      run.schedule('afterRender', () => {
+        if (this.isDestroyed) {
+          return;
+        }
+
+        if (typeof method === 'function') {
+          method(value);
+        } else {
+          invokeAction(this, method, value);
+        }
+      });
     }
   },
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,18 @@
 /*jshint node:true*/
 module.exports = {
-  useVersionCompatibility: true
+  useVersionCompatibility: true,
+  scenarios: [
+    {
+      name: 'ember-alpha',
+      allowedToFail: true,
+      bower: {
+        dependencies: {
+          "ember": "alpha"
+        },
+        resolutions: {
+          "ember": "alpha"
+        }
+      }
+    }
+  ]
 };


### PR DESCRIPTION
* Add `ember-alpha` to ember-try config.
* Fix error with `{{one-way-input` with a `sanitizeInput` function
  provided while running under the glimmer2 engine (and fixes a
  deprecation while running under glimmer1/htmlbars engine).

There are three failing tests in ember-alpha:

- [ ] `Integration | Component | {{one-way-select}}: multiple select`
- [ ] `Integration | Component | {{one-way-select}}: Handles block expression`
- [ ] `Integration | Component | {{one-way-select}}: Handles block expression (option groups)`

Issues have been reported upstream for these failures:

- [ ] https://github.com/emberjs/ember.js/issues/13992 - `<select multiple>` looses multiple selection on initial render
- [ ] https://github.com/emberjs/ember.js/issues/13995 - Yielding inside of an `{{#each` triggers an error.

