### PR TITLE
Fix error being thrown when empty prompt is selected

### DIFF
--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -13,6 +13,7 @@ const {
   get,
   isArray,
   isBlank,
+  isNone,
   isPresent,
   set,
   String: { w }
@@ -165,7 +166,7 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
       foundOption = options.find(findOption);
     }
 
-    if (optionTargetPath) {
+    if (optionTargetPath && !isNone(foundOption)) {
       return get(foundOption, optionTargetPath);
     } else {
       return foundOption;

--- a/tests/integration/components/one-way-select-test.js
+++ b/tests/integration/components/one-way-select-test.js
@@ -365,3 +365,26 @@ test('classNames is not passed as an html attribute', function(assert) {
   this.render(hbs`{{one-way-select classNames="testing"}}`);
   assert.equal(this.$('select').attr('classnames'), undefined);
 });
+
+test('allows to select blank without throwing', function(assert) {
+  let updates = [];
+
+  this.on('update', (newValue) => updates.push(newValue));
+  this.set('value', undefined);
+  this.set('options', [
+    { value: 'one', text: 'One' }
+  ]);
+
+  this.render(hbs`{{one-way-select 
+    prompt='myDefaultPrompt' value=value promptIsSelectable=true options=options optionTargetPath='value' optionValuePath='value' optionLabelPath='text'
+    update=(action 'update')}}`);
+
+  this.$('select').val('one');
+  this.$('select').trigger('change');
+
+  this.$('select').val('');
+  this.$('select').trigger('change');
+
+  assert.equal(this.$('option:selected').text().trim(), 'myDefaultPrompt');
+  assert.deepEqual(updates, ['one', undefined]);
+});


### PR DESCRIPTION
Previously one-way-select threw an error if the user tried to select an empty prompt if `optionTargetPath` was set.

![20160908-150935](https://cloud.githubusercontent.com/assets/1205444/18350918/631e20be-75d8-11e6-885e-8a37b0a4d994.png)
