### PR TITLE
Adding stopPropagation flag on checkbox

### DIFF
--- a/addon/components/one-way-checkbox.js
+++ b/addon/components/one-way-checkbox.js
@@ -20,8 +20,8 @@ const OneWayCheckboxComponent = Component.extend(DynamicAttributeBindings, {
     'value'
   ],
 
-  click() {
-    invokeAction(this, 'update', this.readDOMAttr('checked'));
+  click(event) {
+    invokeAction(this, 'update', this.readDOMAttr('checked'), event);
   },
 
   didReceiveAttrs() {

--- a/tests/integration/components/one-way-checkbox-test.js
+++ b/tests/integration/components/one-way-checkbox-test.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+
+const { set } = Ember;
 
 moduleForComponent('one-way-checkbox', 'Integration | Component | {{one-way-checkbox}}', {
   integration: true
@@ -80,6 +83,31 @@ test('Outside value of undefined', function(assert) {
 });
 
 test('classNames is not passed as an html attribute', function(assert) {
-  this.render(hbs`{{one-way-radio classNames="testing"}}`);
+  this.render(hbs`{{one-way-checkbox classNames="testing"}}`);
   assert.equal(this.$('input').attr('classnames'), undefined);
 });
+
+test('the click event can be intercepted in the action', function(assert) {
+  assert.expect(1);
+
+  this.on('divClick', function() {
+    assert.ok(false);
+  });
+
+  this.on('checkboxClick', function(value, event) {
+    event.stopPropagation();
+
+    set(this, 'checked', value);
+  });
+
+  this.render(hbs`
+    <div {{action 'divClick'}}>
+      {{one-way-checkbox checked update=(action 'checkboxClick')}}
+    </div>
+  `);
+
+  this.$('input').trigger('click');
+
+  assert.equal(this.get('checked'), true);
+});
+


### PR DESCRIPTION
I was trying to use the `one-way-checkbox` component inside a container that also had a click event on it, and it led to some strange behavior. I've added a `stopPropagation` property (`true` by default) to the component to determine whether the click should bubble. If this is considered a breaking change, I'm happy to switch `stopPropagation` to `false` by default.