### PR TITLE
one-way-input should not sync when then component isDestroying is true

### DIFF
--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -56,7 +56,7 @@ const OneWayInputComponent = Component.extend(DynamicAttributeBindings, {
   },
 
   _syncValue() {
-    if (this.isDestroyed) {
+    if (this.isDestroyed || this.isDestroying) {
       return;
     }
 

--- a/tests/integration/components/one-way-input-test.js
+++ b/tests/integration/components/one-way-input-test.js
@@ -228,6 +228,16 @@ test('Handles input masking', function(assert) {
   assert.equal(this.$('input').get(0).selectionStart, 2, 'Cursor is still at right position');
 });
 
+test('Does not update value when it is destroyed', function(assert) {
+  this.set('value', 'foo');
+  this.render(hbs`{{one-way-input value update=(action (mut value))}}`);
+  run(() => {
+    this.clearRender();
+    this.$('input').val('foo bar').trigger('input');
+  });
+  assert.equal(this.get('value'), 'foo', 'Value is still foo');
+});
+
 skip('Works with type="number" and decimals', function(assert) {
   this.render(hbs`{{one-way-input type="number" update=(action (mut value))}}`);
   this.$('input').val('1.').trigger('input');


### PR DESCRIPTION
This change is needed for testing. 

Current code works great on production, but on integration tests a subcomponent that contained a one-way-input was (being) destroyed and `isDestroyed` was false, so it was trying to sync the value and breaking because `this.$()` was undefined (https://github.com/DockYard/ember-one-way-controls/blob/master/addon/components/one-way-input.js#L67). 

However, `isDestroying` was true, so my guess is it should be added to the guard clause. (http://emberjs.com/api/classes/Ember.CoreObject.html#property_isDestroying)

Scenario:
Have an integration test with a complex component. Steps:
1. Render the complex component under test in an integration test
2. Interact with the component to open a modal window (ember-modal-dialog)
3. On that modal window, there is a form with at least one one-way-input
4. Fill in the input, save the form, close the modal window
5. Do some expects wrapped on a `wait` function for the component under test (https://guides.emberjs.com/v2.8.0/testing/testing-components/#toc_waiting-on-asynchronous-behavior)

I could never get to point 5, as the one-way-input was trying to sync the value when the modal window was closed. As the run loop is not the same in test environment, checking if `isDestroying` is needed.
