### PR TITLE
one-way-select component should handle SafeString instances given as "prompt" parameter

### DIFF
--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -30,7 +30,6 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
     'paramValue',
     'prompt',
     'promptIsSelectable',
-    'promptText',
     'includeBlank',
     'optionValuePath',
     'optionLabelPath',
@@ -122,13 +121,6 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
   },
 
   prompt: alias('includeBlank'),
-
-  promptText: computed('prompt', function() {
-    let prompt = get(this, 'prompt');
-    if (typeof prompt === 'string') {
-      return prompt;
-    }
-  }),
 
   _selectedMultiple() {
     let selectedValues = this.$().val() || [];

--- a/addon/templates/components/one-way-select.hbs
+++ b/addon/templates/components/one-way-select.hbs
@@ -2,7 +2,7 @@
   <option value=""
           disabled={{promptIsDisabled}}
           selected={{if nothingSelected "selected"}}>
-    {{promptText}}
+    {{prompt}}
   </option>
 {{/if}}
 {{#if hasGrouping}}

--- a/tests/integration/components/one-way-select-test.js
+++ b/tests/integration/components/one-way-select-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Component, run } = Ember;
+const { Component, run, String: { htmlSafe } } = Ember;
 
 moduleForComponent('one-way-select', 'Integration | Component | {{one-way-select}}', {
   integration: true,
@@ -80,6 +80,12 @@ test('Blank value can be given a text', function(assert) {
 
 test('Prompt is an alias for includeBlank', function(assert) {
   this.render(hbs`{{one-way-select value=value options=options prompt="Select one"}}`);
+  assert.equal(this.$('option:eq(0)').text().trim(), 'Select one', 'The blank option has "Select one" as label');
+});
+
+test('Prompt can be given as SafeString', function(assert) {
+  this.set('promptSafeString', htmlSafe('Select one'));
+  this.render(hbs`{{one-way-select value=value options=options prompt=promptSafeString}}`);
   assert.equal(this.$('option:eq(0)').text().trim(), 'Select one', 'The blank option has "Select one" as label');
 });
 


### PR DESCRIPTION
Test case and removal of faulty `promptText` computed property doing primitive `typeof` check on passed `prompt`. Which was present [since the component was created](https://github.com/DockYard/ember-one-way-controls/commit/37df146cfe32b55335e1d3d69c35e41795785c14#diff-1e1c0b8f693dfb263657157a4576b860R87) and, as far as I can recognise, is not needed for anything.

Related issue: #130 .