### PR TITLE
Update one-way-input.js

### DIFF
--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -56,7 +56,7 @@ const OneWayInputComponent = Component.extend(DynamicAttributeBindings, {
   },
 
   _syncValue() {
-    if (this.isDestroying) {
+    if (this.isDestroying || this.isDestroyed) {
       return;
     }
 

--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -56,7 +56,7 @@ const OneWayInputComponent = Component.extend(DynamicAttributeBindings, {
   },
 
   _syncValue() {
-    if (this.isDestroyed) {
+    if (this.isDestroying) {
       return;
     }
 


### PR DESCRIPTION
I'm having an error in my application that I couldn't quite narrow down to an Ember Twiddle, but I think I know the gist of the problem. When I try to transition (using liquid-fire) from a form to the next route, I get a "Cannot read property 'childNodes' of null" inside of `one-way-input`. After putting a breakpoint there, I saw that the component is `isDestroying: true`, but `isDestroyed: false`.

Applying the change in this PR prevents the error. Let me know if I should also submit a relevant test, and if this changes semantics in an unwanted way.