### PR TITLE
sync the value, only if the element actually exists

### DIFF
--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -56,7 +56,7 @@ const OneWayInputComponent = Component.extend(DynamicAttributeBindings, {
   },
 
   _syncValue() {
-    if (this.isDestroyed) {
+    if (this.isDestroyed || !this.element) {
       return;
     }
 


### PR DESCRIPTION
We experienced some very nasty bugs when using ember-one-way-controls inside ember-light-table cells.

`didReceiveAttrs` calls `_processNewValue` which in turn schedules `_syncValue` in the `afterRender` queue. Normally, the element for the component should have been created by then and `this.readDOMAttr('value')` should succeed.

This was not the case.

`if (this.isDestroyed)` only guards against attempting to read from elements that have been created, but already destroyed.

This PR adds a second check to verify that `this.element` actually exists to guard against reading from elements that yet have to be created.