### PR TITLE
Fix unwanted checked radio

### DIFF
--- a/addon/components/one-way-radio.js
+++ b/addon/components/one-way-radio.js
@@ -6,7 +6,7 @@ const {
   Component,
   computed,
   get,
-  set
+  run: { next }
 } = Ember;
 
 const OneWayRadioComponent = Component.extend(DynamicAttributeBindings, {
@@ -25,28 +25,35 @@ const OneWayRadioComponent = Component.extend(DynamicAttributeBindings, {
     'type'
   ],
 
-  checked: computed('_value', 'option', function() {
-    return get(this, '_value') === get(this, 'option');
+  checked: computed('value', 'option', function() {
+    return get(this, 'value') === this.get('option');
   }),
 
-  click() {
+  click(e) {
+    if (!get(this, 'checked')) {
+      this._triggerChange();
+    }
+    return e.preventDefault();
+  },
+
+  _triggerChange() {
     invokeAction(this, 'update', get(this, 'option'));
   },
 
-  didReceiveAttrs() {
-    this._super(...arguments);
-
-    let value = get(this, 'paramValue');
-    if (value === undefined) {
-      value = get(this, 'value');
+  didUpdateAttrs() {
+    let value = get(this, 'value');
+    let option = get(this, 'option');
+    let checked = get(this, 'checked');
+    if (value || option || checked) {
+      next(()=> {
+        this.$().prop('checked', get(this, 'checked'));
+      });
     }
-
-    set(this, '_value', value);
   }
 });
 
 OneWayRadioComponent.reopenClass({
-  positionalParams: ['paramValue']
+  positionalParams: ['value']
 });
 
 export default OneWayRadioComponent;

--- a/tests/integration/components/one-way-radio-test.js
+++ b/tests/integration/components/one-way-radio-test.js
@@ -1,5 +1,10 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+
+const {
+  run
+} = Ember;
 
 moduleForComponent('one-way-radio', 'Integration | Component | one way radio', {
   integration: true
@@ -79,4 +84,15 @@ test('Outside value of undefined', function(assert) {
 test('classNames is not passed as an html attribute', function(assert) {
   this.render(hbs`{{one-way-radio classNames="testing"}}`);
   assert.equal(this.$('input').attr('classnames'), undefined);
+});
+
+test('Does not check the radio when value is not updated', function(assert) {
+  this.set('value', 'no');
+  this.render(hbs`{{one-way-radio value option="yes" update=(action (mut otherValue))}}`);
+
+  assert.equal(this.$('input:checked').length, 0, 'initially not checked');
+  run(()=> {
+    this.$('input[type=radio]').click();
+  });
+  assert.equal(this.$('input:checked').length, 0, 'still not checked because value does not match');
 });


### PR DESCRIPTION
This PR fixes a bug in `{{one-way-radio}}` where the radio button always gets checked when clicked, whether or not the value equals the `option` of the radio button, which breaks the one-way data flow.

See https://ember-twiddle.com/6c494ec10e13e2030550050a1cce4d24 for a demo of the bug.