### PR TITLE
Made `ember-get-helper` optional, fixes #145

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ This addon will work on Ember versions `1.13.x` and up.
 ember install ember-one-way-controls
 ```
 
+On Ember 1.x you'll also need the `{{get}}` helper polyfill:
+
+```
+ember install ember-get-helper
+```
+
 ## Contributing
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-get-helper": "~1.1.0",
     "ember-invoke-action": "1.4.0",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },


### PR DESCRIPTION
`ember-one-way-controls` includes the `ember-get-helper` addon, which is [officially](https://github.com/jmurphyau/ember-get-helper) "deprecated and support for Ember 2.0 will not be maintained".

This PR makes `ember-get-helper` optional.