### PR TITLE
Fix one-way-checkbox to only toggle if `value` does

### DIFF
--- a/addon/components/one-way-checkbox.js
+++ b/addon/components/one-way-checkbox.js
@@ -6,6 +6,7 @@ const {
   Component,
   computed,
   get,
+  run,
 } = Ember;
 
 const OneWayCheckboxComponent = Component.extend(DynamicAttributeBindings, {
@@ -46,7 +47,9 @@ const OneWayCheckboxComponent = Component.extend(DynamicAttributeBindings, {
 
   _click(event) {
     let checkedProp = this.element.checked;
-    invokeAction(this, 'update', checkedProp, event);
+    run(() => {
+      invokeAction(this, 'update', checkedProp, event);
+    });
 
     let checkedValue = get(this, 'checkedValue');
     this.element.checked = checkedValue;

--- a/addon/components/one-way-checkbox.js
+++ b/addon/components/one-way-checkbox.js
@@ -4,8 +4,8 @@ import DynamicAttributeBindings from '../-private/dynamic-attribute-bindings';
 
 const {
   Component,
+  computed,
   get,
-  set
 } = Ember;
 
 const OneWayCheckboxComponent = Component.extend(DynamicAttributeBindings, {
@@ -15,29 +15,41 @@ const OneWayCheckboxComponent = Component.extend(DynamicAttributeBindings, {
   NON_ATTRIBUTE_BOUND_PROPS: ['update'],
 
   attributeBindings: [
-    'isChecked:checked',
     'type',
     'value'
   ],
 
+  checkedValue: computed('paramChecked', 'checked', function() {
+    let checkedValue = get(this, 'paramChecked');
+
+    if (checkedValue === undefined) {
+      return checkedValue = get(this, 'checked');
+    }
+
+    return checkedValue;
+  }),
+
   didInsertElement() {
     this._super(...arguments);
     this.element.addEventListener('click', (e) => this._click(e));
+
+    const checkedValue = get(this, 'checkedValue');
+    if (checkedValue) {
+      this.element.setAttribute('checked', 'checked');
+    }
   },
 
-  didReceiveAttrs() {
-    this._super(...arguments);
-
-    let value = get(this, 'paramChecked');
-    if (value === undefined) {
-      value = get(this, 'checked');
-    }
-
-    set(this, 'isChecked', value);
+  didUpdateAttrs() {
+    let checkedValue = get(this, 'checkedValue');
+    this.element.checked = checkedValue;
   },
 
   _click(event) {
-    invokeAction(this, 'update', this.readDOMAttr('checked'), event);
+    let checkedProp = this.element.checked;
+    invokeAction(this, 'update', checkedProp, event);
+
+    let checkedValue = get(this, 'checkedValue');
+    this.element.checked = checkedValue;
   },
 });
 

--- a/tests/integration/components/one-way-checkbox-test.js
+++ b/tests/integration/components/one-way-checkbox-test.js
@@ -1,4 +1,4 @@
-import { find, click } from 'ember-native-dom-helpers';
+import { find } from 'ember-native-dom-helpers';
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
@@ -27,7 +27,7 @@ test('It sets the checked value', function(assert) {
 
 test('The first positional param is checked', function(assert) {
   this.render(hbs`{{one-way-checkbox true}}`);
-  assert.ok(find('input:checked'), 'Checkbox is checked');
+  assert.ok(find('input').checked, 'Checkbox is checked');
 });
 
 test('Setting the value property', function(assert) {
@@ -36,32 +36,44 @@ test('Setting the value property', function(assert) {
 });
 
 test('Clicking the checkbox triggers the update action', async function(assert) {
-  this.render(hbs`{{one-way-checkbox update=(action (mut value))}}`);
-  await click('input');
-  assert.equal(this.get('value'), true);
+  this.render(hbs`{{one-way-checkbox value update=(action (mut value))}}`);
 
-  await click('input');
+  find('input').click();
+  assert.equal(this.get('value'), true);
+  
+  find('input').click();
   assert.equal(this.get('value'), false);
 });
 
 test('It can accept an outside toggle of checked', async function(assert) {
-  this.render(hbs`{{one-way-checkbox checked=checked update=(action (mut checked))}}`);
+  this.render(hbs`{{one-way-checkbox checked=checked}}`);
 
-  await click('input');
-  this.set('checked', false);
-  await click('input');
+  this.set('checked', true);
 
+  assert.strictEqual(find('input').checked, true);
   assert.strictEqual(this.get('checked'), true);
 });
 
 test('It can accept an outside toggle of checked - using positional param', async function(assert) {
   this.render(hbs`{{one-way-checkbox checked update=(action (mut checked))}}`);
 
-  await click('input');
-  this.set('checked', false);
-  await click('input');
+  this.set('checked', true);
 
   assert.strictEqual(this.get('checked'), true);
+  assert.strictEqual(find('input').checked, true);
+});
+
+test('Does not toggle state when update action does not modify the value', async function(assert) {
+  this.set('checked', false);
+  this.render(hbs`{{one-way-checkbox checked update=(action (mut checked) false)}}`);
+
+  let inputElement = find('input');
+  
+  assert.strictEqual(inputElement.checked, false, "Checkbox should be unchecked");
+  assert.strictEqual(this.get('false'), undefined, "value should be false");
+  inputElement.click();
+  assert.strictEqual(inputElement.checked, false, "Checkbox should still be unchecked as it is being overriden with update");
+  assert.strictEqual(this.get('checked'), false, "value should be false as it has been set specifically");
 });
 
 test('I can add a class attribute', function(assert) {
@@ -107,8 +119,7 @@ test('the click event can be intercepted in the action', async function(assert) 
     </div>
   `);
 
-  await click('input');
+  find('input').click();
 
   assert.equal(this.get('checked'), true);
 });
-


### PR DESCRIPTION
The physical `<input type=checkbox />` in the component `one-way-checkbox` seems to toggle regardless of whether the `update` callback actually mutates the value. In this sense it is not one-way at all, and will toggle under any condition.  This is outlined in #143 and verified in my own project where I need to display a confirmation dialog when somebody checks an item. 

I have added a test showing the missing functionality on this component wherein a checkbox is made with an empty `update` action, clicks on the checkbox and then verifies whether the actual `.checked` state of the input has changed (representing the actual `checked` property). It seems whomever wrote this component originally thought the `checked` **attribute** is what controls the state of this, but it is in fact a common gotcha within JavaScript that the `checked` attribute only controls a checkboxes _initial_ state, and the `checked` **property** is what manages the actual state of the component. 

I have refactored the `one-way-control` component to properly set the checked Attribute to whatever the first value is, and update the checked Property based on the value passed in. 
Subsequently, and apologies if I should make this two PRs (but this PR depends on it), I have changed calls to `click()` within the `one-way-checkbox` tests to `find('input').click` as it appears the async `click` helper from `ember-native-dom-helpers` does not physically click the item, it only fires the click event itself, which means the state of the checkbox does not change. 