### PR TITLE
Make select prompt hideable

### DIFF
--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -72,6 +72,7 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
 
   nothingSelected: empty('selectedValue'),
   promptIsDisabled: not('promptIsSelectable'),
+  promptIsHidden: not('promptIsSelectable'),
   hasGrouping: or('optionsArePreGrouped', 'groupLabelPath'),
   computedOptionValuePath: or('optionValuePath', 'optionTargetPath'),
 

--- a/addon/templates/components/one-way-select.hbs
+++ b/addon/templates/components/one-way-select.hbs
@@ -1,6 +1,7 @@
 {{#if includeBlank}}
   <option value=""
           disabled={{promptIsDisabled}}
+          hidden={{if promptIsHidden "hidden"}}
           selected={{if nothingSelected "selected"}}>
     {{prompt}}
   </option>

--- a/tests/integration/components/one-way-select-test.js
+++ b/tests/integration/components/one-way-select-test.js
@@ -114,6 +114,11 @@ test('Prompt can be selectable', function(assert) {
   assert.notOk(findAll('option')[0].disabled, 'The blank option is enabled');
 });
 
+test('Prompt can be hidden', function(assert) {
+  this.render(hbs`{{one-way-select value=value options=options prompt="Select one"}}`);
+  assert.ok(findAll('option')[0].hidden, 'The blank option is hidden');
+});
+
 test('optionValuePath', function(assert) {
   let [male, female] = [{ id: 1, value: 'male' }, { id: 2, value: 'female' }];
   this.set('value', female);


### PR DESCRIPTION
Adds the option to hide `one-way-select`'s `prompt`