### PR TITLE
Remove unmaintained "ember-get-helpers" dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-2.0
   - EMBER_TRY_SCENARIO=ember-2.3
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ __Note:__ The cursor jumping issue has been fixed in Ember since 2.3.1.
 
 ## Compatibility
 
-This addon will work on Ember versions `1.13.x` and up.
+This addon will work on Ember versions `2.x` and up.
 
 ## Installing the addon
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,16 +2,15 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-1.13',
+      name: 'ember-2.0',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': '~2.0.0'
         }
       },
       npm: {
         devDependencies: {
           'ember-source': null,
-          'ember-qunit-assert-helpers': null,
           'ember-native-dom-event-dispatcher': null
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-get-helper": "~1.1.0",
     "ember-invoke-action": "1.4.0",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,7 +2124,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.3, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0, ember-cli-version-checker@^1.3.1:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0, ember-cli-version-checker@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -2238,13 +2238,6 @@ ember-export-application-global@^2.0.0:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
-
-ember-get-helper@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-get-helper/-/ember-get-helper-1.1.0.tgz#ef970b199bc1b6a52e986cb744ddf05eb3793051"
-  dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-version-checker "^1.1.3"
 
 ember-hash-helper-polyfill@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
It looks like `ember-one-way-controls` depends on `ember-get-helper`, which depends on `ember-cli-babel@5`, which means we can't drop `ember-cli-shims` from projects using `ember-one-way-controls`.

This PR removes the `ember-get-helper` dependency, which unfortunately means that the minimum Ember version is raised to v2.0.0, so this should probably be considered a breaking change.