### PR TITLE
Fix 'modified twice in single render' assertion thrown in one-way-select

### DIFF
--- a/addon/components/one-way-select.js
+++ b/addon/components/one-way-select.js
@@ -12,7 +12,6 @@ const {
   Object: EmberObject,
   get,
   isArray,
-  isBlank,
   isNone,
   isPresent,
   set,
@@ -63,11 +62,7 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
       set(this, 'optionsArePreGrouped', true);
     }
 
-    if (isBlank(get(this, 'promptIsSelectable'))) {
-      set(this, 'promptIsSelectable', false);
-    }
-
-    set(this, 'options', emberArray(options));
+    set(this, '_options', emberArray(options));
   },
 
   nothingSelected: empty('selectedValue'),
@@ -75,9 +70,9 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
   hasGrouping: or('optionsArePreGrouped', 'groupLabelPath'),
   computedOptionValuePath: or('optionValuePath', 'optionTargetPath'),
 
-  optionGroups: computed('options.[]', function() {
+  optionGroups: computed('_options.[]', function() {
     let groupLabelPath = get(this, 'groupLabelPath');
-    let options = get(this, 'options');
+    let options = get(this, '_options');
     let groups = emberArray();
 
     if (!groupLabelPath) {
@@ -141,7 +136,7 @@ const OneWaySelectComponent = Component.extend(DynamicAttributeBindings, {
   },
 
   _findOption(value) {
-    let options = get(this, 'options');
+    let options = get(this, '_options');
     let optionValuePath = get(this, 'computedOptionValuePath');
     let optionTargetPath = get(this, 'optionTargetPath');
     let optionsArePreGrouped = get(this, 'optionsArePreGrouped');

--- a/addon/templates/components/one-way-select.hbs
+++ b/addon/templates/components/one-way-select.hbs
@@ -32,7 +32,7 @@
     </optgroup>
   {{/each}}
 {{else}}
-  {{#each options as |option index|}}
+  {{#each _options as |option index|}}
     {{#if hasBlock}}
       {{#one-way-select/option
           selected=selectedValue


### PR DESCRIPTION
Avoid modifying passed in attributes directly in the `didReceiveAttrs` hook to
ensure we don't modify the same property several times in one render.

Also setting `promptIsSelectable` to false isn't really necessary, since the prop that actually disables selecting the prompt is `promptIsDisabled`. It will give a give a falsy value anyways.

This seems like the preferred solution over #157.