### PR TITLE
Ember 3.x compatibility

### DIFF
--- a/addon/components/one-way-textarea.js
+++ b/addon/components/one-way-textarea.js
@@ -8,6 +8,6 @@ export default OneWayInputComponent.extend({
 
     // We need to unset type, otherwise it will try to set it
     // on the element, which results in an error on textarea.
-    this.type = undefined;
+    this.set('type', undefined);
   }
 });


### PR DESCRIPTION
In the current beta channel (3.0-beta), the tests for this addon
are failing because of the use of an explicit ES setter instead of
an explicit Ember `.set()` in `{{one-way-textarea}}`.